### PR TITLE
update zoapp-front dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "request-promise-native": "^1.0.5",
     "timezones.json": "^1.3.3",
     "zoapp-common": "0.1.0",
-    "zoapp-front": "^0.8.0",
+    "zoapp-front": "^0.13.0",
     "zoapp-ui": "^0.4.7",
     "zrmc": "^0.10.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1891,25 +1891,6 @@ css-loader@^0.28.10:
     postcss-value-parser "^3.3.0"
     source-list-map "^2.0.0"
 
-css-loader@^0.28.7:
-  version "0.28.9"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-0.28.9.tgz#68064b85f4e271d7ce4c48a58300928e535d1c95"
-  dependencies:
-    babel-code-frame "^6.26.0"
-    css-selector-tokenizer "^0.7.0"
-    cssnano "^3.10.0"
-    icss-utils "^2.1.0"
-    loader-utils "^1.0.2"
-    lodash.camelcase "^4.3.0"
-    object-assign "^4.1.1"
-    postcss "^5.0.6"
-    postcss-modules-extract-imports "^1.2.0"
-    postcss-modules-local-by-default "^1.2.0"
-    postcss-modules-scope "^1.1.0"
-    postcss-modules-values "^1.3.0"
-    postcss-value-parser "^3.3.0"
-    source-list-map "^2.0.0"
-
 css-select@^1.1.0, css-select@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
@@ -4458,10 +4439,6 @@ jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
 
-json-loader@0.5.4:
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.4.tgz#8baa1365a632f58a3c46d20175fc6002c96e37de"
-
 json-loader@^0.5.4, json-loader@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.7.tgz#dca14a70235ff82f0ac9a3abeb60d337a365185d"
@@ -6163,6 +6140,15 @@ react@16.2.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+react@^16.2.0:
+  version "16.3.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.3.1.tgz#4a2da433d471251c69b6033ada30e2ed1202cfd8"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
 read-pkg-up@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
@@ -7040,13 +7026,6 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-style-loader@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.19.1.tgz#591ffc80bcefe268b77c5d9ebc0505d772619f85"
-  dependencies:
-    loader-utils "^1.0.2"
-    schema-utils "^0.3.0"
-
 style-loader@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.20.2.tgz#851b373c187890331776e9cde359eea9c95ecd00"
@@ -7859,15 +7838,13 @@ zoapp-common@0.1.2:
   dependencies:
     winston "2.4.0"
 
-zoapp-front@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/zoapp-front/-/zoapp-front-0.8.0.tgz#07c51fc11ab18fb57b1474d4e8cbfa3de3ea9721"
+zoapp-front@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/zoapp-front/-/zoapp-front-0.13.0.tgz#3e4b2d83b1ec095625c23714c42ec76dbc89f473"
   dependencies:
     babel-runtime "^6.26.0"
-    css-loader "^0.28.7"
-    json-loader "0.5.4"
     prop-types "15.6.0"
-    react "16.2.0"
+    react "^16.2.0"
     react-dom "16.2.0"
     react-hot-loader "^4.0.0"
     react-redux "5.0.6"
@@ -7875,7 +7852,6 @@ zoapp-front@^0.8.0:
     react-router-dom "^4.2.2"
     redux "3.7.2"
     redux-saga "0.16.0"
-    style-loader "^0.19.1"
     zoapp-common "0.1.2"
     zoapp-ui "0.4.7"
     zrmc "^0.8.1"


### PR DESCRIPTION
I closed #70 to work on this PR.

So i updated `zoapp-front` with the command `yarn add zoapp-front@^0.13.0` and here again react is updated. I think this is because the react dependency in `zoapp-front` is `^16.2.01 and not `16.2.0`, this change was made in this commit https://github.com/Zoapp/front/commit/7a6360040f1c06c780d34acfc56151485ef7771c

But I don't understand why yarn behave like this