### PR TITLE
[WIP] create a middleware to handle not log out anymore users

### DIFF
--- a/src/shared/middleware/signoutMiddleware.js
+++ b/src/shared/middleware/signoutMiddleware.js
@@ -1,0 +1,16 @@
+import { FETCH_FAILURE } from "zoapp-front/actions/constants";
+import { signOut } from "zoapp-front/actions/auth";
+
+const middleware = (store) => (next) => (action) => {
+  const result = next(action);
+
+  const regex = new RegExp(`^.*${FETCH_FAILURE}$`);
+  if (regex.test(action.type)) {
+    console.log(action);
+    store.dispatch(signOut({ provider: store.getState().auth.provider }));
+  }
+
+  return result;
+};
+
+export default middleware;

--- a/src/shared/store.js
+++ b/src/shared/store.js
@@ -8,6 +8,7 @@ import { createStore, applyMiddleware, compose } from "redux";
 import createSagaMiddleware from "redux-saga";
 import reducers from "./reducers";
 import rootSaga from "./sagas";
+import signoutMiddleware from "./middleware/signoutMiddleware";
 
 export default function configureStore(initialState = {}) {
   const sagaMiddleware = createSagaMiddleware();
@@ -19,7 +20,7 @@ export default function configureStore(initialState = {}) {
   const store = createStore(
     reducers,
     initialState,
-    composeEnhancers(applyMiddleware(sagaMiddleware)),
+    composeEnhancers(applyMiddleware(sagaMiddleware, signoutMiddleware)),
   );
 
   sagaMiddleware.run(rootSaga);


### PR DESCRIPTION
I started this PR to fix issue #79 but I can't continue it while issue https://github.com/Zoapp/common/issues/2 is not treated.

I have no idea while the request fail, I can't use the error message.

Moreover I think this PR should be done in zoapp/front.

The idea is to create a redux middleware and if the action is a failure **and** status code is 401 then I should dispatch the signout action.