### PR TITLE
Changes on templatesList design

### DIFF
--- a/src/public/css/main.css
+++ b/src/public/css/main.css
@@ -662,17 +662,14 @@
  /* templatesList (.opla_template) Component Style */
 .opla_template-templateBox {
   position: relative;
-  height: 280px;
-  width: 200px;
+  height: 320px;
   outline: 5px solid transparent;
   text-decoration: none;
 }
 
  .opla_template-infoC {
-  font-size: 16px;
-  font-weight: 300;
   color: #FFF;
-  height: 210px;
+  height: 250px;
   opacity: 0.6;
   filter: alpha(opacity=60); /* For IE8 and earlier */
 }
@@ -680,7 +677,7 @@
 .opla_template-imgCell {
   position: relative;
   width: 100%;
-  height: 210px;
+  height: 250px;
   background-color: #f5f5f5;
 }
 
@@ -714,8 +711,12 @@
 }
 
 .opla_template-textCell {
-  padding: 16px;
-  line-height: "1.6";
+  font-weight: 200;
+  font-size: 1.1em;
+  line-height: 1.1em;
+  height: 2.2em;
+  overflow: hidden;
+  padding: 1rem;
   background-color: rgb(69, 90, 100);
 }
 

--- a/src/public/css/main.css
+++ b/src/public/css/main.css
@@ -662,8 +662,8 @@
  /* templatesList (.opla_template) Component Style */
 .opla_template-templateBox {
   position: relative;
-  height: 250px;
-  width: 150px;
+  height: 280px;
+  width: 200px;
   outline: 5px solid transparent;
   text-decoration: none;
 }
@@ -672,7 +672,7 @@
   font-size: 16px;
   font-weight: 300;
   color: #FFF;
-  height: 180px;
+  height: 210px;
   opacity: 0.6;
   filter: alpha(opacity=60); /* For IE8 and earlier */
 }
@@ -680,7 +680,8 @@
 .opla_template-imgCell {
   position: relative;
   width: 100%;
-  height: 180px;
+  height: 210px;
+  background-color: #f5f5f5;
 }
 
 .opla_template-backgroundCell{
@@ -698,7 +699,7 @@
 
 .opla_template-img {
   position: absolute;  
-  width: 80px;
+  width: 100px;
   text-align: center;
   margin: 0;
   top: 50%;

--- a/src/public/css/main.css
+++ b/src/public/css/main.css
@@ -661,9 +661,11 @@
  
  /* templatesList (.opla_template) Component Style */
 .opla_template-templateBox {
+  position: relative;
   height: 250px;
+  width: 150px;
   outline: 5px solid transparent;
-  text-decoration: "none";
+  text-decoration: none;
 }
 
  .opla_template-infoC {
@@ -671,13 +673,14 @@
   font-weight: 300;
   color: #FFF;
   height: 180px;
+  opacity: 0.6;
+  filter: alpha(opacity=60); /* For IE8 and earlier */
 }
 
 .opla_template-imgCell {
   position: relative;
   width: 100%;
   height: 180px;
-  background-color: rgb(245, 245, 245);
 }
 
 .opla_template-backgroundCell{
@@ -694,7 +697,8 @@
 }
 
 .opla_template-img {
-  width: 80px;position: absolute;  
+  position: absolute;  
+  width: 80px;
   text-align: center;
   margin: 0;
   top: 50%;
@@ -703,12 +707,9 @@
   transform: translate(-50%, -50%);
 }
 
-.opla_template-templateBox:hover .opla_template-imgCell {
-  background-color: #EEE;
-}
-
-.opla_template-templateBox:hover .opla_template-imgMask {
-  background-color: rgba(255, 255, 255, 0.4);
+.opla_template-templateBox:hover .opla_template-infoC {
+  opacity: 1;
+  filter: alpha(opacity=100); /* For IE8 and earlier */
 }
 
 .opla_template-textCell {
@@ -717,9 +718,15 @@
   background-color: rgb(69, 90, 100);
 }
 
-.opla_template-templateBox .selectedListItem {
-  outline: 5px solid rgba(86, 38, 130, 0.80);
+.opla_template-templateBox .opla_template-infoC.selectedListItem {
+  opacity: 1;
+  filter: alpha(opacity=100); /* For IE8 and earlier */
 }
+
+.opla_template-templateBox .opla_template-infoC.selectedListItem .opla_template-textCell {
+  color: #FFEB3B;
+}
+
 
 /* Override fileInput */
 .opla_template-templateBox .fileInput {

--- a/src/shared/components/templatesList.jsx
+++ b/src/shared/components/templatesList.jsx
@@ -9,6 +9,7 @@ import PropTypes from "prop-types";
 import { Grid, Inner, Cell } from "zrmc";
 import makeClassName from "classnames";
 import FileInput from "zoapp-front/components/fileInput";
+import { robotsColors} from "../utils/robotsColors";
 
 const TemplatesList = ({
   items,
@@ -28,7 +29,12 @@ const TemplatesList = ({
         });
 
         return (
-          <Cell key={key} className="opla_template-templateBox" span={2}>
+          <Cell
+            key={key}
+            className="opla_template-templateBox"
+            span={1}
+            order={item.name === "Empty" ? 1 : 2}
+          >
             <div
               role="presentation"
               style={{ width: "100%" }}
@@ -46,7 +52,8 @@ const TemplatesList = ({
                     <div
                       className="opla_template-backgroundCell"
                       style={{
-                        backgroundImage: `url(./images/robots/robot-${index}.svg)`,
+                        backgroundColor:
+                          robotsColors[`robot-${index}`].mainColor,
                       }}
                     >
                       <div className="opla_template-imgMask">

--- a/src/shared/components/templatesList.jsx
+++ b/src/shared/components/templatesList.jsx
@@ -32,7 +32,7 @@ const TemplatesList = ({
           <Cell
             key={key}
             className="opla_template-templateBox"
-            span={1}
+            spanDevice={{ desktop: 2, tablet: 4, phone: 6 }}
             order={item.name === "Empty" ? 1 : 2}
           >
             <div

--- a/src/shared/components/templatesList.jsx
+++ b/src/shared/components/templatesList.jsx
@@ -9,7 +9,7 @@ import PropTypes from "prop-types";
 import { Grid, Inner, Cell } from "zrmc";
 import makeClassName from "classnames";
 import FileInput from "zoapp-front/components/fileInput";
-import { robotsColors} from "../utils/robotsColors";
+import { robotsColors } from "../utils/robotsColors";
 
 const TemplatesList = ({
   items,

--- a/src/shared/utils/robotsColors.js
+++ b/src/shared/utils/robotsColors.js
@@ -1,0 +1,23 @@
+/* eslint import/prefer-default-export: 0 */
+export const robotsColors = {
+  "robot-0": {
+    mainColor: "#4cdbc4",
+    name: "robot-0",
+  },
+  "robot-1": {
+    mainColor: "#54c0eb",
+    name: "robot-1",
+  },
+  "robot-2": {
+    mainColor: "#84DBFF",
+    name: "robot-2",
+  },
+  "robot-3": {
+    mainColor: "#324A5E",
+    name: "robot-3",
+  },
+  "robot-4": {
+    mainColor: "#90DFAA",
+    name: "robot-4",
+  },
+};

--- a/tests/shared/components/__snapshots__/templatesList.test.js.snap
+++ b/tests/shared/components/__snapshots__/templatesList.test.js.snap
@@ -8,7 +8,7 @@ exports[`components/TemplatesList creates a form for the 'Import' special item 1
     className="mdc-layout-grid__inner"
   >
     <div
-      className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-2"
+      className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-1 mdc-layout-grid__cell--order-2"
     >
       <div
         onClick={[Function]}
@@ -64,7 +64,7 @@ exports[`components/TemplatesList marks an item as selected 1`] = `
     className="mdc-layout-grid__inner"
   >
     <div
-      className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-2"
+      className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-1 mdc-layout-grid__cell--order-2"
     >
       <div
         onClick={[Function]}
@@ -85,7 +85,7 @@ exports[`components/TemplatesList marks an item as selected 1`] = `
               className="opla_template-backgroundCell"
               style={
                 Object {
-                  "backgroundImage": "url(./images/robots/robot-0.svg)",
+                  "backgroundColor": "#4cdbc4",
                 }
               }
             >
@@ -111,7 +111,7 @@ exports[`components/TemplatesList marks an item as selected 1`] = `
       </div>
     </div>
     <div
-      className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-2"
+      className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-1 mdc-layout-grid__cell--order-2"
     >
       <div
         onClick={[Function]}
@@ -132,7 +132,7 @@ exports[`components/TemplatesList marks an item as selected 1`] = `
               className="opla_template-backgroundCell"
               style={
                 Object {
-                  "backgroundImage": "url(./images/robots/robot-1.svg)",
+                  "backgroundColor": "#54c0eb",
                 }
               }
             >
@@ -179,7 +179,7 @@ exports[`components/TemplatesList renders some items 1`] = `
     className="mdc-layout-grid__inner"
   >
     <div
-      className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-2"
+      className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-1 mdc-layout-grid__cell--order-2"
     >
       <div
         onClick={[Function]}
@@ -200,7 +200,7 @@ exports[`components/TemplatesList renders some items 1`] = `
               className="opla_template-backgroundCell"
               style={
                 Object {
-                  "backgroundImage": "url(./images/robots/robot-0.svg)",
+                  "backgroundColor": "#4cdbc4",
                 }
               }
             >
@@ -237,7 +237,7 @@ exports[`components/TemplatesList renders without selected template 1`] = `
     className="mdc-layout-grid__inner"
   >
     <div
-      className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-2"
+      className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-1 mdc-layout-grid__cell--order-2"
     >
       <div
         onClick={[Function]}
@@ -258,7 +258,7 @@ exports[`components/TemplatesList renders without selected template 1`] = `
               className="opla_template-backgroundCell"
               style={
                 Object {
-                  "backgroundImage": "url(./images/robots/robot-0.svg)",
+                  "backgroundColor": "#4cdbc4",
                 }
               }
             >
@@ -284,7 +284,7 @@ exports[`components/TemplatesList renders without selected template 1`] = `
       </div>
     </div>
     <div
-      className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-2"
+      className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-1 mdc-layout-grid__cell--order-2"
     >
       <div
         onClick={[Function]}
@@ -305,7 +305,7 @@ exports[`components/TemplatesList renders without selected template 1`] = `
               className="opla_template-backgroundCell"
               style={
                 Object {
-                  "backgroundImage": "url(./images/robots/robot-1.svg)",
+                  "backgroundColor": "#54c0eb",
                 }
               }
             >

--- a/tests/shared/components/__snapshots__/templatesList.test.js.snap
+++ b/tests/shared/components/__snapshots__/templatesList.test.js.snap
@@ -8,7 +8,7 @@ exports[`components/TemplatesList creates a form for the 'Import' special item 1
     className="mdc-layout-grid__inner"
   >
     <div
-      className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-1 mdc-layout-grid__cell--order-2"
+      className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-2-desktop mdc-layout-grid__cell--span-4-tablet mdc-layout-grid__cell--span-6-phone mdc-layout-grid__cell--order-2"
     >
       <div
         onClick={[Function]}
@@ -64,7 +64,7 @@ exports[`components/TemplatesList marks an item as selected 1`] = `
     className="mdc-layout-grid__inner"
   >
     <div
-      className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-1 mdc-layout-grid__cell--order-2"
+      className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-2-desktop mdc-layout-grid__cell--span-4-tablet mdc-layout-grid__cell--span-6-phone mdc-layout-grid__cell--order-2"
     >
       <div
         onClick={[Function]}
@@ -111,7 +111,7 @@ exports[`components/TemplatesList marks an item as selected 1`] = `
       </div>
     </div>
     <div
-      className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-1 mdc-layout-grid__cell--order-2"
+      className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-2-desktop mdc-layout-grid__cell--span-4-tablet mdc-layout-grid__cell--span-6-phone mdc-layout-grid__cell--order-2"
     >
       <div
         onClick={[Function]}
@@ -179,7 +179,7 @@ exports[`components/TemplatesList renders some items 1`] = `
     className="mdc-layout-grid__inner"
   >
     <div
-      className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-1 mdc-layout-grid__cell--order-2"
+      className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-2-desktop mdc-layout-grid__cell--span-4-tablet mdc-layout-grid__cell--span-6-phone mdc-layout-grid__cell--order-2"
     >
       <div
         onClick={[Function]}
@@ -237,7 +237,7 @@ exports[`components/TemplatesList renders without selected template 1`] = `
     className="mdc-layout-grid__inner"
   >
     <div
-      className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-1 mdc-layout-grid__cell--order-2"
+      className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-2-desktop mdc-layout-grid__cell--span-4-tablet mdc-layout-grid__cell--span-6-phone mdc-layout-grid__cell--order-2"
     >
       <div
         onClick={[Function]}
@@ -284,7 +284,7 @@ exports[`components/TemplatesList renders without selected template 1`] = `
       </div>
     </div>
     <div
-      className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-1 mdc-layout-grid__cell--order-2"
+      className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-2-desktop mdc-layout-grid__cell--span-4-tablet mdc-layout-grid__cell--span-6-phone mdc-layout-grid__cell--order-2"
     >
       <div
         onClick={[Function]}

--- a/tests/shared/containers/__snapshots__/createAssistant.test.js.snap
+++ b/tests/shared/containers/__snapshots__/createAssistant.test.js.snap
@@ -86,7 +86,7 @@ exports[`containers/CreateAssistant renders correctly 1`] = `
         className="mdc-layout-grid__inner"
       >
         <div
-          className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-1 mdc-layout-grid__cell--order-1"
+          className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-2-desktop mdc-layout-grid__cell--span-4-tablet mdc-layout-grid__cell--span-6-phone mdc-layout-grid__cell--order-1"
         >
           <div
             onClick={[Function]}
@@ -133,7 +133,7 @@ exports[`containers/CreateAssistant renders correctly 1`] = `
           </div>
         </div>
         <div
-          className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-1 mdc-layout-grid__cell--order-2"
+          className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-2-desktop mdc-layout-grid__cell--span-4-tablet mdc-layout-grid__cell--span-6-phone mdc-layout-grid__cell--order-2"
         >
           <div
             onClick={[Function]}

--- a/tests/shared/containers/__snapshots__/createAssistant.test.js.snap
+++ b/tests/shared/containers/__snapshots__/createAssistant.test.js.snap
@@ -86,7 +86,7 @@ exports[`containers/CreateAssistant renders correctly 1`] = `
         className="mdc-layout-grid__inner"
       >
         <div
-          className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-2"
+          className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-1 mdc-layout-grid__cell--order-1"
         >
           <div
             onClick={[Function]}
@@ -107,7 +107,7 @@ exports[`containers/CreateAssistant renders correctly 1`] = `
                   className="opla_template-backgroundCell"
                   style={
                     Object {
-                      "backgroundImage": "url(./images/robots/robot-0.svg)",
+                      "backgroundColor": "#4cdbc4",
                     }
                   }
                 >
@@ -133,7 +133,7 @@ exports[`containers/CreateAssistant renders correctly 1`] = `
           </div>
         </div>
         <div
-          className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-2"
+          className="opla_template-templateBox mdc-layout-grid__cell mdc-layout-grid__cell--span-1 mdc-layout-grid__cell--order-2"
         >
           <div
             onClick={[Function]}


### PR DESCRIPTION
Link to https://github.com/Opla/front/issues/112
- [x] empty template at first
- [x] when not selected nor focused, set opacity to 0.6
- [x] yellow color for selected item text (see MD for correct rgb value)
- [x] also aspect ratio of items should be the same if you resize screen.
