### PR TITLE
Fix intent edit dialog close issue

### DIFF
--- a/src/shared/components/intentDetail.jsx
+++ b/src/shared/components/intentDetail.jsx
@@ -6,7 +6,14 @@
  */
 import React from "react";
 import PropTypes from "prop-types";
-import Zrmc, { List, ListItem, ListItemMeta, TextField, Button } from "zrmc";
+import Zrmc, {
+  DialogManager,
+  List,
+  ListItem,
+  ListItemMeta,
+  TextField,
+  Button,
+} from "zrmc";
 import { ExpansionPanel } from "zoapp-ui";
 import ActionsList from "../components/actionsList";
 import ActionEditor from "../components/actionEditor";
@@ -174,6 +181,10 @@ export const displayActionEditor = (
     body: content,
     actions: [{ name: "Cancel" }, { name: actionDef, title: action }],
     onAction: onEditAction,
+    onClose: () => {
+      onEditAction(null, "Cancel");
+      DialogManager.close();
+    },
     style: { width: "720px" },
   });
 };


### PR DESCRIPTION
fix Opla/community-edition#25

---
Note:
On Dialog a "Cancel" click call `IntentAction.handleEditAction` with the param editAction='Cancel'
`IntentAction.handleEditAction` call `IntentAction.reset()` how set `IntentAction.actionContainer` to undefined. This allow `IntentAction.handleDoActions` to call `IntentAction.handleChangeAction` otherwise it just `return`.

The dialog is created by `IntentAction.handleActions` who call `displayActionEditor` a function defined in components/intentDetail.jsx file (not in the component) who call `Zrmc.showDialog` with a dialog object.

I added a onClose props function to this dialog object, how calls `onEditAction` with a cancel action and `DialogManager.close()` (like the default onClose props does)
