### PR TITLE
Fix intent editing

### DIFF
--- a/src/shared/components/actionsEditable.jsx
+++ b/src/shared/components/actionsEditable.jsx
@@ -322,6 +322,7 @@ class ActionsEditable extends Component {
         start = (
           <span
             id={id}
+            key={id}
             tabIndex={i}
             data="text"
             style={styleText}
@@ -343,6 +344,7 @@ class ActionsEditable extends Component {
         end = (
           <span
             id={id}
+            key={id}
             tabIndex={l}
             data="text"
             style={styleText}
@@ -364,7 +366,7 @@ class ActionsEditable extends Component {
               return (
                 <span
                   className="mdl-chip"
-                  key={id}
+                  key={id + type}
                   id={id}
                   style={styleAny}
                   ref={(e) => {
@@ -380,7 +382,7 @@ class ActionsEditable extends Component {
               return (
                 <span
                   className="mdl-chip"
-                  key={id}
+                  key={id + type}
                   id={id}
                   style={styleOut}
                   ref={(e) => {
@@ -394,11 +396,11 @@ class ActionsEditable extends Component {
                   </span>
                 </span>
               );
-            } else if (actionItem.type === "variable") {
+            } else if (type === "variable") {
               return (
                 <span
                   className="mdl-chip"
-                  key={id}
+                  key={id + type}
                   id={id}
                   style={styleVar}
                   ref={(e) => {
@@ -412,11 +414,11 @@ class ActionsEditable extends Component {
                   </span>
                 </span>
               );
-            } else if (actionItem.type === "br") {
+            } else if (type === "br") {
               return (
                 <span
                   className="mdl-chip"
-                  key={id}
+                  key={id + type}
                   id={id}
                   style={styleHtml}
                   ref={(e) => {
@@ -430,11 +432,11 @@ class ActionsEditable extends Component {
                   </span>
                 </span>
               );
-            } else if (actionItem.type === "button") {
+            } else if (type === "button") {
               return (
                 <span
                   className="mdl-chip"
-                  key={id}
+                  key={id + type}
                   id={id}
                   style={styleHtml}
                   ref={(e) => {
@@ -449,7 +451,7 @@ class ActionsEditable extends Component {
             }
             return (
               <span
-                key={id}
+                key={id + type}
                 id={id}
                 style={styleText}
                 data="text"

--- a/src/shared/components/actionsEditable.jsx
+++ b/src/shared/components/actionsEditable.jsx
@@ -240,13 +240,13 @@ class ActionsEditable extends Component {
 
   insertItem(item, position = this.state.selectedItem + 1) {
     const { items } = this.state;
-    // console.log("insert item ", position, this.focusItem);
+    // console.log("insert item: ", item, position, this.focusElement);
 
     let p = position;
-    if (this.focusItem) {
-      if (this.focusItem === "ae_start") {
+    if (this.focusElement) {
+      if (this.focusElement.id === "ae_start") {
         p = 0;
-      } else if (this.focusItem === "ae_end") {
+      } else if (this.focusElement.id === "ae_end") {
         p = items.length;
       }
     }
@@ -265,9 +265,12 @@ class ActionsEditable extends Component {
 
   deleteItem(position = this.state.selectedItem) {
     const { items } = this.state;
-    if (this.focusItem) {
-      if (this.focusItem === "ae_start" || this.focusItem === "ae_end") {
-        this.focusItem.innerHtml = "";
+    if (this.focusElement) {
+      if (
+        this.focusElement.id === "ae_start" ||
+        this.focusElement.id === "ae_end"
+      ) {
+        this.focusElement.id.innerHtml = "";
       }
     }
     // console.log("delete item ", position);

--- a/src/shared/components/actionsEditable.jsx
+++ b/src/shared/components/actionsEditable.jsx
@@ -98,6 +98,8 @@ class ActionsEditable extends Component {
 
   handleBlur = () => {
     // console.log("onBlur");
+    // forceUpdate to sync state and actions span rendered
+    this.forceUpdate();
     this.unfocus();
   };
 
@@ -248,12 +250,8 @@ class ActionsEditable extends Component {
     // console.log("insert item: ", item, position, this.focusElement);
 
     let p = position;
-    if (this.focusElement) {
-      if (this.focusElement.id === "ae_start") {
-        p = 0;
-      } else if (this.focusElement.id === "ae_end") {
-        p = items.length;
-      }
+    if (this.focusElement && this.focusElement.id === "ae_end") {
+      p = items.length;
     }
     if (p < items.length) {
       items.splice(p, 0, item);
@@ -274,18 +272,19 @@ class ActionsEditable extends Component {
 
   deleteItem(position = this.state.selectedItem) {
     const { items } = this.state;
-    if (this.focusElement) {
-      if (
-        this.focusElement.id === "ae_start" ||
-        this.focusElement.id === "ae_end"
-      ) {
-        this.focusElement.id.innerHtml = "";
-      }
+    let deletePosition = position;
+    // if focus on ae_end and last action is a text, remove text
+    if (
+      this.focusElement &&
+      this.focusElement.id === "ae_end" &&
+      items[items.length - 1].type === "text"
+    ) {
+      deletePosition = items.length - 1;
     }
-    // console.log("delete item ", position);
-    if (position > -1 && position < items.length) {
-      items.splice(position, 1);
-      const selectedItem = position - 1;
+    // console.log("delete item ", deletePosition);
+    if (deletePosition > -1 && deletePosition < items.length) {
+      items.splice(deletePosition, 1);
+      const selectedItem = deletePosition - 1;
       const content = ActionsEditable.build(items);
       const noUpdate = false;
       this.setState({ noUpdate, content, items, selectedItem }, () => {

--- a/src/shared/components/actionsEditable.jsx
+++ b/src/shared/components/actionsEditable.jsx
@@ -209,17 +209,11 @@ class ActionsEditable extends Component {
     this.props.onFocus(false, this); */
   };
 
-  setCE = (e, editable = true, focus = false /* , type = "text" */) => {
+  setCE = (e, editable = true) => {
     if (!e) return;
-    // console.log("setCE editable=", editable, focus, e.id);
+    // console.log("setCE editable=", editable, e.id);
     if (editable) {
       e.contentEditable = this.props.editable;
-    }
-    if (focus) {
-      if (e) {
-        this.focusElement = e;
-        e.focus();
-      }
     }
   };
 
@@ -319,10 +313,8 @@ class ActionsEditable extends Component {
       // console.log("render", this.state.selectedItem, len);
       if (len < 1 || (actions[0] && actions[0].type !== "text")) {
         id = "ae_start";
-        let f = false;
         if (len < 1) {
-          styleText.width = "100wv";
-          f = true;
+          styleText.width = "100vw";
         }
         start = (
           <span
@@ -331,7 +323,7 @@ class ActionsEditable extends Component {
             data="text"
             style={styleText}
             ref={(e) => {
-              this.setCE(e, true, f);
+              this.setCE(e, true);
             }}
           />
         );
@@ -345,8 +337,6 @@ class ActionsEditable extends Component {
       if (actions[l] && actions[l].type !== "text" && this.props.editable) {
         id = "ae_end";
         l = len + i;
-        const f = this.state.selectedItem === -1;
-        // console.log("ae_end focus=", f);
         end = (
           <span
             id={id}
@@ -354,15 +344,10 @@ class ActionsEditable extends Component {
             data="text"
             style={styleText}
             ref={(e) => {
-              this.setCE(e, true, f);
+              this.setCE(e, true);
             }}
           />
         );
-      }
-      // console.log("focus", focus);
-      let { selectedItem } = this.state;
-      if (this.props.editable && this.state.selectedItem === -1) {
-        selectedItem = len - 1;
       }
       list = (
         <span>
@@ -371,11 +356,6 @@ class ActionsEditable extends Component {
             id = `ae_${index}`;
             const p = i;
             i += 1;
-            let focus = false;
-            if (index === selectedItem) {
-              focus = true;
-            }
-            // console.log(id, " focus", focus);
             const { type } = actionItem;
             if (type === "any") {
               return (
@@ -385,7 +365,7 @@ class ActionsEditable extends Component {
                   id={id}
                   style={styleAny}
                   ref={(e) => {
-                    this.setCE(e, false, focus, type);
+                    this.setCE(e, false);
                   }}
                   data="any"
                   tabIndex={p}
@@ -401,7 +381,7 @@ class ActionsEditable extends Component {
                   id={id}
                   style={styleOut}
                   ref={(e) => {
-                    this.setCE(e, true, focus, type);
+                    this.setCE(e, true);
                   }}
                   data="output_var"
                   tabIndex={p}
@@ -419,7 +399,7 @@ class ActionsEditable extends Component {
                   id={id}
                   style={styleVar}
                   ref={(e) => {
-                    this.setCE(e, true, focus, type);
+                    this.setCE(e, true);
                   }}
                   data="variable"
                   tabIndex={p}
@@ -437,7 +417,7 @@ class ActionsEditable extends Component {
                   id={id}
                   style={styleHtml}
                   ref={(e) => {
-                    this.setCE(e, false, focus, type);
+                    this.setCE(e, false);
                   }}
                   data="br"
                   tabIndex={p}
@@ -455,7 +435,7 @@ class ActionsEditable extends Component {
                   id={id}
                   style={styleHtml}
                   ref={(e) => {
-                    this.setCE(e, true, focus, type);
+                    this.setCE(e, true);
                   }}
                   data="button"
                   tabIndex={p}
@@ -471,7 +451,7 @@ class ActionsEditable extends Component {
                 style={styleText}
                 data="text"
                 ref={(e) => {
-                  this.setCE(e, true, focus);
+                  this.setCE(e, true);
                 }}
                 tabIndex={p}
               >

--- a/src/shared/components/actionsEditable.jsx
+++ b/src/shared/components/actionsEditable.jsx
@@ -51,8 +51,10 @@ class ActionsEditable extends Component {
       noUpdate: false,
       startSpan: null,
       endSpan: null,
+      itemToFocus: null,
     };
     this.focusElement = null;
+    this.itemsElementRefs = [];
   }
 
   /* eslint-disable class-methods-use-this */
@@ -209,9 +211,12 @@ class ActionsEditable extends Component {
     this.props.onFocus(false, this); */
   };
 
-  setCE = (e, editable = true) => {
+  setCE = (e, editable = true, itemIndex = null) => {
     if (!e) return;
-    // console.log("setCE editable=", editable, e.id);
+    // save items refs
+    if (itemIndex !== null) {
+      this.itemsElementRefs[itemIndex] = e;
+    }
     if (editable) {
       e.contentEditable = this.props.editable;
     }
@@ -255,12 +260,16 @@ class ActionsEditable extends Component {
     } else {
       items.push(item);
     }
+
     const selectedItem = p;
     const content = ActionsEditable.build(items);
     const noUpdate = false;
-    this.setState({ noUpdate, content, items, selectedItem }, () => {
-      this.props.onChange(content);
-    });
+    this.setState(
+      { noUpdate, content, items, selectedItem, itemToFocus: p },
+      () => {
+        this.props.onChange(content);
+      },
+    );
   }
 
   deleteItem(position = this.state.selectedItem) {
@@ -370,7 +379,7 @@ class ActionsEditable extends Component {
                   id={id}
                   style={styleAny}
                   ref={(e) => {
-                    this.setCE(e, false);
+                    this.setCE(e, false, index);
                   }}
                   data="any"
                   tabIndex={p}
@@ -386,7 +395,7 @@ class ActionsEditable extends Component {
                   id={id}
                   style={styleOut}
                   ref={(e) => {
-                    this.setCE(e, true);
+                    this.setCE(e, true, index);
                   }}
                   data="output_var"
                   tabIndex={p}
@@ -404,7 +413,7 @@ class ActionsEditable extends Component {
                   id={id}
                   style={styleVar}
                   ref={(e) => {
-                    this.setCE(e, true);
+                    this.setCE(e, true, index);
                   }}
                   data="variable"
                   tabIndex={p}
@@ -422,7 +431,7 @@ class ActionsEditable extends Component {
                   id={id}
                   style={styleHtml}
                   ref={(e) => {
-                    this.setCE(e, false);
+                    this.setCE(e, false, index);
                   }}
                   data="br"
                   tabIndex={p}
@@ -440,7 +449,7 @@ class ActionsEditable extends Component {
                   id={id}
                   style={styleHtml}
                   ref={(e) => {
-                    this.setCE(e, true);
+                    this.setCE(e, true, index);
                   }}
                   data="button"
                   tabIndex={p}
@@ -456,7 +465,7 @@ class ActionsEditable extends Component {
                 style={styleText}
                 data="text"
                 ref={(e) => {
-                  this.setCE(e, true);
+                  this.setCE(e, true, index);
                 }}
                 tabIndex={p}
               >
@@ -492,6 +501,16 @@ class ActionsEditable extends Component {
         {list}
       </div>
     );
+  }
+
+  componentDidUpdate() {
+    const { itemToFocus } = this.state;
+    if (itemToFocus !== null) {
+      // call focus on item reference
+      const element = this.itemsElementRefs[itemToFocus];
+      element.focus();
+      this.setState({ itemToFocus: null });
+    }
   }
 }
 

--- a/tests/shared/components/actionsEditable.test.js
+++ b/tests/shared/components/actionsEditable.test.js
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2015-present, CWB SAS
+ *
+ * This source code is licensed under the GPL v2.0+ license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from "react";
+import { shallow } from "enzyme";
+import ActionsEditable from "shared/components/actionsEditable";
+
+describe("components/actionsEditable", () => {
+  const defaultProps = {
+    id: "action-editor-content",
+    editable: true,
+    content: "* bons gestes composteur *",
+    onChange: () => {},
+    onSelected: () => {},
+    style: {
+      overflow: "hidden",
+      fontSize: "16px",
+      letterSpacing: "0.04em",
+      lineHeight: "1",
+      color: "#757575",
+      margin: "16px",
+    },
+    selectedItem: -1,
+    onFocus: () => {},
+    onAction: () => {},
+    // placeholder: null,
+    // caretPosition: 0
+  };
+
+  it("renders correctly", () => {
+    const wrapper = shallow(<ActionsEditable {...defaultProps} />);
+    expect(wrapper.state("items")).toHaveLength(3);
+    expect(wrapper.find("#ae_content")).toHaveLength(1);
+    expect(wrapper.find("#ae_1")).toHaveLength(1);
+    expect(wrapper.find("#ae_1").text()).toEqual(" bons gestes composteur ");
+  });
+
+  it("should insert an item", () => {
+    const wrapper = shallow(<ActionsEditable {...defaultProps} />);
+    expect(wrapper.state("items")).toHaveLength(3);
+    expect(wrapper.find("#ae_1")).toHaveLength(1);
+    expect(wrapper.find("#ae_1").text()).toEqual(" bons gestes composteur ");
+
+    const focusElement = {
+      id: "ae_1",
+      innerHTML: " bons gestes composteur ",
+      tabindex: 3,
+      contenteditable: true,
+    };
+    wrapper.instance().focusElement = focusElement;
+    wrapper.instance().insertItem({ text: "*", type: "any" }, 2);
+    wrapper.update();
+    expect(wrapper.state("items")).toHaveLength(4);
+    expect(wrapper.find("#ae_2")).toHaveLength(1);
+    expect(wrapper.find("#ae_2").text()).toEqual("any");
+    expect(wrapper.find("#ae_3")).toHaveLength(1);
+    expect(wrapper.find("#ae_3").text()).toEqual("any");
+  });
+
+  it("should insert an item at end", () => {
+    const wrapper = shallow(
+      <ActionsEditable {...defaultProps} content="* bons gestes composteur " />,
+    );
+    expect(wrapper.state("items")).toHaveLength(2);
+    expect(wrapper.find("#ae_0")).toHaveLength(1);
+    expect(wrapper.find("#ae_0").text()).toEqual("any");
+    expect(wrapper.find("#ae_1")).toHaveLength(1);
+    expect(wrapper.find("#ae_1").text()).toEqual(" bons gestes composteur ");
+
+    const focusElement = {
+      id: "ae_end",
+      innerHTML: "",
+      tabindex: 7,
+      contenteditable: true,
+    };
+    wrapper.instance().focusElement = focusElement;
+    wrapper.instance().insertItem({ text: "*", type: "any" }, 0);
+    wrapper.update();
+    expect(wrapper.state("items")).toHaveLength(3);
+    expect(wrapper.find("#ae_0")).toHaveLength(1);
+    expect(wrapper.find("#ae_0").text()).toEqual("any");
+    expect(wrapper.find("#ae_1")).toHaveLength(1);
+    expect(wrapper.find("#ae_1").text()).toEqual(" bons gestes composteur ");
+    expect(wrapper.find("#ae_2")).toHaveLength(1);
+    expect(wrapper.find("#ae_2").text()).toEqual("any");
+    expect(wrapper.find("#ae_3")).toHaveLength(0);
+  });
+
+  it("should delete an item", () => {
+    const wrapper = shallow(
+      <ActionsEditable
+        {...defaultProps}
+        content="* bons gestes composteur **"
+      />,
+    );
+    expect(wrapper.state("items")).toHaveLength(4);
+    expect(wrapper.find("#ae_1")).toHaveLength(1);
+    expect(wrapper.find("#ae_1").text()).toEqual(" bons gestes composteur ");
+    expect(wrapper.find("#ae_2")).toHaveLength(1);
+    expect(wrapper.find("#ae_2").text()).toEqual("any");
+    expect(wrapper.find("#ae_3")).toHaveLength(1);
+    expect(wrapper.find("#ae_3").text()).toEqual("any");
+
+    const focusElement = {
+      id: "ae_2",
+      tabindex: 3,
+      contenteditable: true,
+    };
+    wrapper.instance().focusElement = focusElement;
+    wrapper.instance().deleteItem(2);
+    wrapper.update();
+    expect(wrapper.state("items")).toHaveLength(3);
+    expect(wrapper.find("#ae_2")).toHaveLength(1);
+    expect(wrapper.find("#ae_2").text()).toEqual("any");
+    expect(wrapper.find("#ae_3")).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Fix Opla/community-edition#24

- [x] fix multiple handlefocus call
- [x] fix simultaneous span with focus=true
- [x] fix insert item when ae_end focused
- [x] fix "any" become editable when in first position and text are added before it
- [x] selects new item
- [x] fix ae_start content duplication
- [x] fix ae_end remove content.
---
note:
The 'any' editable bug is caused by React reusing element whenever it can, with some exception like key change. As key is set to Id and Id represent the position, span (with contenteditable set to true by the ref callback) is reused and create a bug.