### PR TITLE
Remove actionsEditable content state copy

### DIFF
--- a/src/shared/components/actionsEditable.jsx
+++ b/src/shared/components/actionsEditable.jsx
@@ -44,7 +44,6 @@ class ActionsEditable extends Component {
     const { content, selectedItem, caretPosition } = this.props;
     const items = ActionsTools.parse(content);
     this.state = {
-      content,
       items,
       selectedItem,
       caretPosition,
@@ -56,10 +55,9 @@ class ActionsEditable extends Component {
   }
 
   static getDerivedStateFromProps(props, state) {
-    const { content, caretPosition } = props;
-    if (content !== state.content) {
+    const { caretPosition } = props;
+    if (caretPosition !== state.caretPosition) {
       return {
-        content,
         caretPosition,
       };
     }
@@ -95,7 +93,7 @@ class ActionsEditable extends Component {
     }
     if (e.which === 13) {
       // WIP handle save event
-      const text = this.state.content;
+      const text = this.props.content;
       e.preventDefault();
       if (this.props.isNew) {
         this.props.onAddAction(text);

--- a/src/shared/containers/agentManager.jsx
+++ b/src/shared/containers/agentManager.jsx
@@ -33,6 +33,9 @@ class AgentManager extends Component {
     super(props);
     this.state = { needUpdate: true };
     this.props.appSetTitle("Builder");
+  }
+
+  componentDidMount() {
     this.updateIntents();
   }
 

--- a/tests/shared/components/actionsEditable.test.js
+++ b/tests/shared/components/actionsEditable.test.js
@@ -13,6 +13,7 @@ describe("components/actionsEditable", () => {
     id: "action-editor-content",
     editable: true,
     content: "* bons gestes composteur *",
+    caretPosition: 2,
     onChange: () => {},
     onSelected: () => {},
     style: {
@@ -50,13 +51,10 @@ describe("components/actionsEditable", () => {
 
   it("should update state if content props change", () => {
     const wrapper = shallow(<ActionsEditable {...defaultProps} />);
-    expect(wrapper.state("content")).toEqual(defaultProps.content);
-    // save original build items to compare
-    const orgBuildItems = wrapper.state("items");
+    expect(wrapper.state("caretPosition")).toEqual(defaultProps.caretPosition);
 
-    wrapper.setProps({ content: "foo *" });
-    expect(wrapper.state("content")).toEqual("foo *");
-    expect(wrapper.state("items")).not.toEqual(orgBuildItems);
+    wrapper.setProps({ caretPosition: 1 });
+    expect(wrapper.state("caretPosition")).toEqual(1);
   });
 
   describe("build()", () => {


### PR DESCRIPTION
Trying to keep a Single Source of Truth for actionsEditable content (intent string content)